### PR TITLE
feat: add restrict invalid JSON input functionality to the readJSON h…

### DIFF
--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/julienschmidt/httprouter"
 )
@@ -44,7 +45,13 @@ func (app *application) writeJSON(wr http.ResponseWriter, status int, data envel
 }
 
 func (app *application) readJSON(wr http.ResponseWriter, r *http.Request, dest interface{}) error {
-	err := json.NewDecoder(r.Body).Decode(dest)
+	maxBytes := 1_048_576
+	r.Body = http.MaxBytesReader(wr, r.Body, int64(maxBytes))
+
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+
+	err := dec.Decode(dest)
 	if err != nil {
 		var syntaxError *json.SyntaxError
 		var unmarshalTypeError *json.UnmarshalTypeError
@@ -62,11 +69,24 @@ func (app *application) readJSON(wr http.ResponseWriter, r *http.Request, dest i
 			return fmt.Errorf("body contains incorrect JSON type (at character %d)", unmarshalTypeError.Offset)
 		case errors.Is(err, io.EOF):
 			return errors.New("body must not be empty")
+		case strings.HasPrefix(err.Error(), "json: unknown field "):
+			fieldName := strings.TrimPrefix(err.Error(), "json: unknown field ")
+
+			return fmt.Errorf("body contains unknown key %s", fieldName)
+		case err.Error() == "http: request body too large":
+			return fmt.Errorf("body must not be larger than %d bytes", maxBytes)
 		case errors.As(err, &invalidUnmarshalError):
 			panic(err)
+		
 		default:
 			return err
 		}
 	}
+
+	err = dec.Decode(&struct{}{})
+	if err != io.EOF {
+		return errors.New("body must contain only a single JSON value")
+	}
+
 	return nil
 }


### PR DESCRIPTION
…elper method

- check for large request bodies and return an appropriate error
- check for invalid type fields and return an appropriate error
- check for more than a single JSON object passed as a request body and return an appropriate error
- add a max_bytes cap to the size of the request