### PR TITLE
chore: graceful shutdown of background go-routine tasks

### DIFF
--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -139,8 +139,13 @@ func (app *application) readJSON(rw http.ResponseWriter, r *http.Request, dest i
 }
 
 func (app *application) background(fn func()) {
+	// Increment the WaitGroup counter.
+	app.wg.Add(1)
 	// Launch a background goroutine
 	go func() {
+		// Use defer to decrement the WaitGroup counter before the goroutine returns.
+		defer app.wg.Done()
+	
 		// Run a deferred function which uses recover() to catch any panic, and log an 
 		// error message instead of terminating the application.
 		defer func() {
@@ -153,3 +158,5 @@ func (app *application) background(fn func()) {
 		fn()
 	}()
 }
+
+

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"flag"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/mycok/sunrise-api/internal/data"
@@ -46,6 +47,7 @@ type application struct {
 	logger *jsonlog.Logger
 	models data.Models
 	mailer mailer.Mailer
+	wg sync.WaitGroup
 }
 
 func openDB(cfg config) (*sql.DB, error) {

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -46,7 +46,23 @@ func (app *application) serve() error {
 		// error (which may happen because of a problem closing the listeners, or
 		// because the shutdown didn't complete before the 5-second context deadline is hit).
 		//  We relay this return value to the shutdownError channel.
-		shutdownError <- srv.Shutdown(ctx)
+		err := srv.Shutdown(ctx)
+		if err != nil {
+			shutdownError <- err
+		}
+
+		// Log a message to say that we're waiting for any background goroutines to 
+		// complete their tasks.
+		app.logger.PrintInfo("completing background tasks", map[string]string{
+			"addr": srv.Addr,	
+		})
+
+		// Call Wait() to block until our WaitGroup counter is zero --- essentially
+		// blocking until the background goroutines have finished. Then we return nil on
+		// the shutdownError channel, to indicate that the shutdown completed without
+		// any issues.
+		app.wg.Wait()
+		shutdownError <- nil
 	}()
 
 	app.logger.PrintInfo("starting server", map[string]string{


### PR DESCRIPTION
- add and use the sync.WaitGroup type to monitor the execution of background go-routines
- integrate the sync.WaitGroup functionality with the server helper function in order to wait for on-going background tasks to complete before the app graceful shutdown occurs