### PR TITLE
feat: send activation token

### DIFF
--- a/internal/data/tokens.go
+++ b/internal/data/tokens.go
@@ -84,7 +84,7 @@ func (m TokenModel) New(userID int64, timeToLive time.Duration, scope string) (*
 func(m TokenModel) Insert(token *Token) error {
 	query := `
 			INSERT INTO tokens (hash, user_id, expiry, scope)
-			VALUES $1, $2, $3, $4`
+			VALUES ($1, $2, $3, $4)`
 
 	args := []interface{}{token.Hash, token.UserID, token.Expiry, token.Scope}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/internal/mailer/templates/user_welcome.go.tmpl
+++ b/internal/mailer/templates/user_welcome.go.tmpl
@@ -5,7 +5,13 @@ Hi,
 
 Thank you for signing up with sunrise account. We are excited to have you on board!
 
-For future reference, your user ID number is {{.ID}}.
+For future reference, your user ID number is {{.userID}}.
+
+Please send a request to `PUT /v1/users/activated` endpoint with the following JSON body to activate your account.
+
+{"token": "{{.activationToken}}"}
+
+Please note that this is a one-time use token and it will expire in 3 days.
 
 Thanks,
 
@@ -22,7 +28,10 @@ The Sunrise Team
 
     <body>
         <p>Hi,</p>
-        <p>Thanks for signing up for a Greenlight account. We're excited to have you on board!</p> <p>For future reference, your user ID number is {{.ID}}.</p>
+        <p>Thanks for signing up for a Greenlight account. We're excited to have you on board!</p> <p>For future reference, your user ID number is {{.userID}}.</p>
+        <p>Please send a request to <code>PUT /v1/users/activated</code> endpoint with the following JSON body to activate your account.</p>
+        <pre><code>{"token": "{{.activationToken}}"}</code></pre>
+        <p>Please note that this is a one-time use token and it will expire in 3 days.</p>
         <p>Thanks,</p>
         <p>The Greenlight Team</p>
     </body>


### PR DESCRIPTION
- add activation_token data to the data type passed to the templates
- add generate_token helper for generating the plain_text token and hash encryption
- add token generation functionality to register_user_handler